### PR TITLE
Enable some basic configurations in a YAML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ rake yard:publish
 
 Easy as that!
 
+## Optional Configuration
+
+Include a file called .yard-gh-pages.yml in the root of your project.
+
+Options:
+- source_branch (default: 'master')
+  - Branch that should be used to pull the latest directory of generated YARD files
+- source_directory (default: 'docs')
+  - Directory within the source_branch that contains the generated YARD files
+- destination_branch (default: 'gh-pages')
+  - Branch within github where the YARD files should be pushed. 'gh-pages' is also the default branch used by Github.
+
+Example file:
+```yaml
+source_branch: 'master'
+source_directory: 'docs'
+destination_branch: 'gh-pages'
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/yard-ghpages.rb
+++ b/lib/yard-ghpages.rb
@@ -1,6 +1,7 @@
 require 'yard-ghpages/version'
 require 'yard-ghpages/branch_merger'
 
+require 'yaml'
 require 'yard'
 
 module Yard
@@ -23,9 +24,20 @@ module Yard
 
           desc 'Publish documentation to gh-pages'
           task :publish do |t|
+            source_branch = 'master'
+            source_directory = 'docs'
+            destination_branch = 'gh-pages' 
+
+            config_filename = '.yard-gh-pages.yml'
+            if File.file?(config_filename)
+              config_file = YAML.load_file(config_filename)
+              source_branch = config_file.fetch('source_branch', source_branch)
+              source_directory = config_file.fetch('source_directory', source_directory)
+              destination_branch = config_file.fetch('destination_branch', destination_branch)
+            end
             Yard::GHPages::BranchMerger.new do |g|
-              g.source = { branch: 'master', directory: 'doc' }
-              g.destination = { branch: 'gh-pages'}
+              g.source = { branch: source_branch, directory: source_directory }
+              g.destination = { branch: destination_branch }
               g.message = 'Updated website' # defaults to 'Updated files.'
             end.merge.push
           end


### PR DESCRIPTION
**Why this PR?**
In the project I'd like to use this for, it's not feasible for me to use either the 'docs' folder or actually commit the generated YARD files to master. 

**What Changed?**
Add ability to include a YAML file which can configure the source directory and branch, as well as the destination branch.