### PR TITLE
README: syntax highlight the Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or install it yourself as:
 This gem exposes two new rake tasks: `yard:build` and `yard:publish`.
 
 To use this gem, install in the `Rakefile`.
-```
+```ruby
 require 'yard-ghpages'
 Yard::GHPages::Tasks.install_tasks
 ```


### PR DESCRIPTION
This PR adds syntax highlighting to the README to improve readability. :sparkles: